### PR TITLE
Fixes for supporting proxy

### DIFF
--- a/kube-deploy/roles/deploy-kube/tasks/centos.yml
+++ b/kube-deploy/roles/deploy-kube/tasks/centos.yml
@@ -50,19 +50,26 @@
 
 - name: setting up docker unit drop-in dir
   file: path=/etc/systemd/system/docker.service.d state=directory
-  when: docker_shared_mounts
+  when: docker_shared_mounts or proxy_enable
 
 - name: setting up docker shared mounts
   template: src="10-docker-shared-mounts.conf.j2" dest="/etc/systemd/system/docker.service.d/10-docker-shared-mounts.conf" mode=0640
   when: docker_shared_mounts
   register: dsm
 
+# Vagrant's proxyconf plugin doesn't properly set up docker proxy and
+# even if it did, would require a reboot of the VMs after docker install.
+- name: setting up docker proxy
+  template: src="20-docker-proxy.conf.j2" dest="/etc/systemd/system/docker.service.d/20-docker-proxy.conf" mode=0640
+  when: proxy_enable
+  register: docker_proxy
+
 - name: reload systemd config
   command: systemctl daemon-reload
-  when: dsm.changed
+  when: dsm.changed or docker_proxy.changed
 
 - name: start docker service
-  service: enabled=yes state=started name=docker
+  service: enabled=yes state=restarted name=docker
 
 - name: start kubelet service
   service: enabled=yes state=started name=kubelet

--- a/kube-deploy/roles/deploy-kube/templates/20-docker-proxy.conf.j2
+++ b/kube-deploy/roles/deploy-kube/templates/20-docker-proxy.conf.j2
@@ -1,0 +1,4 @@
+[Service]
+Environment="HTTP_PROXY={{ proxy_http }}"
+Environment="HTTPS_PROXY={{ proxy_https }}"
+Environment="NO_PROXY={{ proxy_no }}"

--- a/kube-deploy/roles/upgrade-os/tasks/centos.yml
+++ b/kube-deploy/roles/upgrade-os/tasks/centos.yml
@@ -49,7 +49,7 @@
   shell: yum install -y epel-release
 
 - name: installing ceph repo
-  shell: rpm -Uhv http://download.ceph.com/rpm-jewel/el7/noarch/ceph-release-1-1.el7.noarch.rpm
+  yum: name=http://download.ceph.com/rpm-jewel/el7/noarch/ceph-release-1-1.el7.noarch.rpm state=present
 
 - name: installing ceph
   shell: yum install -y ceph


### PR DESCRIPTION
The vagrant-proxyconf plugin doesn't properly set up the docker proxy for centos (it also requires a vagrant reload after docker is installed which causes problems with the ansible playbook).  This change creates a docker proxy conf file to correctly apply proxy settings for docker.

This change depends on a change to the Vagrantfile to pass extra variables into ansible (see https://github.com/att-comdev/halcyon-vagrant-kubernetes/pull/12) and should **not** be merged until that pull request is accepted.  However, I wanted to publish it now so the two pull requests could be seen together.